### PR TITLE
Better type support, add disabled property

### DIFF
--- a/src/lib/DropFile.svelte
+++ b/src/lib/DropFile.svelte
@@ -2,6 +2,7 @@
   import FallbackSvg from './DropFileFallbackSvg.svelte'
 
   export let multiple: boolean = false
+  export let disabled: boolean = false
   export let onDrop: (files: File[]) => void
   export let onEnter: () => void = () => {}
   export let onLeave: () => void = () => {}
@@ -11,22 +12,26 @@
 
   const handleEnter = () => {
     isOver = true
-    if (onEnter) { onEnter() }
+    if (onEnter) {
+      onEnter()
+    }
   }
 
   const handleLeave = () => {
     isOver = false
-    if (onLeave) { onLeave() }
+    if (onLeave) {
+      onLeave()
+    }
   }
 
-  const handleDrop = (e: Event) => {
+  const handleDrop = (e: DragEvent) => {
     e.preventDefault()
-    // @ts-ignore
-    console.log(e.dataTransfer)
-    // @ts-ignore
-    const items = Array.from(e.dataTransfer.items)
-    // @ts-ignore
-    onDrop(items.map(d => d.getAsFile()))
+
+    if (!e?.dataTransfer?.items || disabled) {
+      return
+    }
+    const items = Array.from(e.dataTransfer.files)
+    onDrop(items)
     isOver = false
   }
 
@@ -36,11 +41,8 @@
 
   const handleChange = (e: Event) => {
     e.preventDefault()
-    // @ts-ignore
-    if (e.target && e.target.files) {
-      // @ts-ignore
-      onDrop(Array.from(e.target.files))
-    }
+    const files: FileList = <FileList>(<HTMLInputElement>e.target).files
+    onDrop(Array.from(files))
   }
 
   const onClick = () => {
@@ -76,6 +78,7 @@
   on:change={handleChange}
   bind:this={input}
   {multiple}
+  {disabled}
 />
 
 <style>
@@ -88,7 +91,7 @@
   }
   #fallback {
     display: grid;
-	  align-items: center;
+    align-items: center;
     width: 100%;
     height: 200px;
     border: black solid 1px;


### PR DESCRIPTION
For the DropFile component
- Better type support
- Add disabled

I didn't add styles for the disabled state b/c with the current structure one needed to add another class to #fallback probably. I think in general, a better solution would be to not hide the input with `display: none;` but rather just make it invisible with opacity. Additionally, it could be moved inside (or before) the drop zone so it can be used to style the dropzone based on state. E.g.

```css
input:disabled + #fallback {
   opacity: 0.5;
   ...
}
``` 

Same with focus. The original input should receive the focus and you could style the dropzone with `:focus-within`. 

